### PR TITLE
add foreground and background start methods

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,10 +63,10 @@ $manager->update('selenium'); //only update selenium
 
 $manager->clean(); //remove installed binaries
 
-$manager->start(); //start selenium in the foreground on port 4444
-$manager->start(false, 9999); //start selenium in the foreground on port 9999
-$manager->start(true); //start selenium in the background on port 4444
-$manager->start(true, 9999); //start in the background on port 9999 
+$manager->startInForeground(); //start selenium in the foreground on port 4444
+$manager->startInForeground(9999); //start selenium in the foreground on port 9999
+$manager->startInBackground(); //start selenium in the background on port 4444
+$manager->startInBackground(9999); //start in the background on port 9999 
 
 $path = $manager->getInstallPath(); //where binaries are installed
 $manager->setInstallPath(__DIR__); //set the path to install binaries

--- a/specs/console/start-command.spec.php
+++ b/specs/console/start-command.spec.php
@@ -27,7 +27,7 @@ describe('StartCommand', function () {
     describe('->execute()', function () {
         it('should update and start', function () {
             $this->update->run(Argument::any(), Argument::any())->shouldBeCalled();
-            $this->manager->start(false, 4444)->shouldBeCalled();
+            $this->manager->startInForeground(4444)->shouldBeCalled();
 
             $command = $this->application->find('start');
             $tester = new CommandTester($command);
@@ -38,7 +38,7 @@ describe('StartCommand', function () {
         context('when port is supplied', function () {
             it('should use the specified port if available', function () {
                 $this->update->run(Argument::any(), Argument::any())->shouldBeCalled();
-                $this->manager->start(false, 9000)->shouldBeCalled();
+                $this->manager->startInForeground(9000)->shouldBeCalled();
 
                 $command = $this->application->find('start');
                 $tester = new CommandTester($command);

--- a/src/Console/StartCommand.php
+++ b/src/Console/StartCommand.php
@@ -42,7 +42,7 @@ class StartCommand extends AbstractManagerCommand
         $update->run(new ArrayInput(['command' => 'update']), $output);
 
         $output->writeln('<info>Starting Selenium Server...</info>');
-        $this->manager->start(false, $port);
+        $this->manager->startInForeground($port);
         return 0;
     }
 } 

--- a/src/Manager.php
+++ b/src/Manager.php
@@ -217,6 +217,28 @@ class Manager implements EventEmitterInterface
     }
 
     /**
+     * Start Selenium in the foreground.
+     *
+     * @param int $port
+     * @return SeleniumProcessInterface
+     */
+    public function startInForeground($port = 4444)
+    {
+        return $this->start(false, $port);
+    }
+
+    /**
+     * Start Selenium in a background process.
+     *
+     * @param int $port
+     * @return SeleniumProcessInterface
+     */
+    public function startInBackground($port = 4444)
+    {
+        return $this->start(true, $port);
+    }
+
+    /**
      * Remove all binaries from the install path.
      *
      * @return void


### PR DESCRIPTION
Adds background and foreground specific start methods to `Manager`
- `$manager->startInForeground($port)`
- `$manager->startInBackground($port)`
