### PR TITLE
manager inherits from newly set resolver

### DIFF
--- a/specs/manager.spec.php
+++ b/specs/manager.spec.php
@@ -75,6 +75,23 @@ describe('Manager', function () {
         });
     });
 
+    describe('->setBinaryResolver()', function () {
+        it('should inherit events from the new binary resolver', function () {
+            $resolver = new BinaryResolver();
+            $manager = new Manager();
+            $manager->setBinaryResolver($resolver);
+            $progress = 0;
+
+            $manager->on('progress', function ($p) use (&$progress) {
+                $progress = $p;
+            });
+
+            $resolver->emit('progress', [50]);
+
+            expect($progress)->to->equal(50);
+        });
+    });
+
     describe('->removeBinary()', function () {
         it('should remove a binary from the collection of managed binaries', function () {
             $this->manager->removeBinary('selenium');

--- a/src/Manager.php
+++ b/src/Manager.php
@@ -53,11 +53,11 @@ class Manager implements EventEmitterInterface
         $this->process = $process;
         $this->binaries = [];
 
-        $this->addBinary(new SeleniumStandalone($this->getBinaryResolver()));
-        $this->addBinary(new ChromeDriver($this->getBinaryResolver()));
-        $this->addBinary(new IEDriver($this->getBinaryResolver()));
-
-        $this->inherit(['progress', 'request.start', 'complete'], $this->getBinaryResolver());
+        $resolver = $this->getBinaryResolver();
+        $this->addBinary(new SeleniumStandalone($resolver));
+        $this->addBinary(new ChromeDriver($resolver));
+        $this->addBinary(new IEDriver($resolver));
+        $this->setBinaryResolver($resolver);
     }
 
     /**
@@ -104,6 +104,7 @@ class Manager implements EventEmitterInterface
     public function setBinaryResolver(BinaryResolverInterface $resolver)
     {
         $this->resolver = $resolver;
+        $this->inherit(['progress', 'request.start', 'complete'], $resolver);
     }
 
     /**


### PR DESCRIPTION
When used as a library the manager did not inherit events from a new `BinaryResolver` provided via `$manager->setBinaryResolver()`.

This PR ensures that the `progress`, `complete`, and `request.start` events of a set `BinaryResolver` are inherited.
