### PR TITLE
Run commands through `exec` on POSIX compliant OS to avoid zombie procceses.

### DIFF
--- a/specs/process/selenium-process.spec.php
+++ b/specs/process/selenium-process.spec.php
@@ -32,7 +32,8 @@ describe('SeleniumProcess', function () {
         it('should return a java command with the arguments joined', function () {
             $this->process->addArg('-port', 9000);
             $command = $this->process->getCommand();
-            expect($command)->to->equal('java -jar -port 9000');
+            $prefix = strtoupper(substr(PHP_OS, 0, 3)) !== 'WIN' ? 'exec ' : '';
+            expect($command)->to->equal($prefix . 'java -jar -port 9000');
         });
     });
 

--- a/src/Binary/ChromeDriver.php
+++ b/src/Binary/ChromeDriver.php
@@ -133,6 +133,12 @@ class ChromeDriver extends CompressedBinary implements DriverInterface
      */
     public function getExtractedName()
     {
-        return $this->getName();
+        $name = $this->getName();
+        $system = $this->resolver->getSystem();
+
+        if ($system->isWindows()) {
+            $name .= '.exe';
+        }
+        return $name;
     }
 }

--- a/src/Process/SeleniumProcess.php
+++ b/src/Process/SeleniumProcess.php
@@ -99,7 +99,7 @@ class SeleniumProcess implements SeleniumProcessInterface
     {
         $command = 'java -version';
         $descriptors = $this->getDescriptorSpec();
-        $this->process = proc_open($command, $descriptors, $this->pipes);
+        $this->process = proc_open($this->formatCommand($command), $descriptors, $this->pipes);
         $status = $this->getStatus(true);
         $available = $status['exitcode'] == 0;
         proc_close($this->process);
@@ -131,7 +131,7 @@ class SeleniumProcess implements SeleniumProcessInterface
      */
     public function getCommand()
     {
-        return 'java ' . implode(' ', $this->args);
+        return $this->formatCommand('java ' . implode(' ', $this->args));
     }
 
     /**
@@ -180,6 +180,20 @@ class SeleniumProcess implements SeleniumProcessInterface
     {
         proc_terminate($this->process);
         return proc_close($this->process);
+    }
+
+    /**
+     * Format a shell command according to the running Operating System to avoid zombie processes.
+     *
+     * @param string $command A shell command.
+     * @return string
+     */
+    private function formatCommand($command)
+    {
+        if (strtoupper(substr(PHP_OS, 0, 3)) === 'WIN') {
+            return $command;
+        }
+        return 'exec ' . $command;
     }
 
     /**


### PR DESCRIPTION
It solves the following issue https://github.com/peridot-php/webdriver-manager/issues/11 by using a trick posted in the last comment of https://bugs.php.net/bug.php?id=39992
