### PR TITLE
Bumps selenium standalone and chrome driver versions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,5 +18,10 @@ install:
   - composer install --prefer-source
 
 script:
-  - vendor/bin/peridot 
+  - vendor/bin/peridot
   - vendor/bin/peridot --grep *.it.php
+
+addons:
+  apt:
+    packages:
+      - oracle-java8-installer

--- a/src/Binary/ChromeDriver.php
+++ b/src/Binary/ChromeDriver.php
@@ -32,7 +32,7 @@ class ChromeDriver extends CompressedBinary implements DriverInterface
         $system = $this->resolver->getSystem();
 
         if ($system->isMac()) {
-            $file .= 'mac32';
+            $file .= 'mac64';
         }
 
         if ($system->isWindows()) {

--- a/src/Versions.php
+++ b/src/Versions.php
@@ -7,13 +7,13 @@ namespace Peridot\WebDriverManager;
  *
  * @package Peridot\WebDriverManager
  */
-class Versions 
+class Versions
 {
-    const SELENIUM = '2.48.2';
+    const SELENIUM = '3.0.1';
 
-    const CHROMEDRIVER = '2.19';
+    const CHROMEDRIVER = '2.27';
 
     const IEDRIVER = '2.48.0';
 
     const MANAGER = '1.4.0';
-} 
+}


### PR DESCRIPTION
@hackel pointed out that the currently pinned version of chrome driver no longer works. It also looks like google only provides 64 bit binaries for the mac driver now.

This PR updates chrome driver to the latest, as well as selenium standalone.

I'm going to hold of on a PR to auto detect for now because most version bumps carry a functional setup for some time before needing an update.

Also leaving IEDriver alone for now because integration tests are all passing still, and I don't ever IE. If someone opens an issue requesting edge, we can revisit this.

fixes https://github.com/peridot-php/webdriver-manager/issues/15